### PR TITLE
Change `from_dict` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.6.1 - 2021-09-28
+- Changed `from_dict` method for building the token payload with all possible keys
+
 ## v0.6.0 - 2021-09-23
 - Dropped support for HS256
 - Made TokenSecurity class lazy load TokenManager

--- a/armasec/token_decoder.py
+++ b/armasec/token_decoder.py
@@ -89,6 +89,6 @@ class TokenDecoder:
             )
             self.debug_logger(f"Payload dictionary is {payload_dict}")
             self.debug_logger("Attempting to convert to TokenPayload")
-            token_payload = TokenPayload.from_dict(payload_dict)
+            token_payload = TokenPayload(**payload_dict)
             self.debug_logger(f"Built token_payload as {token_payload}")
             return token_payload

--- a/armasec/token_payload.py
+++ b/armasec/token_payload.py
@@ -3,10 +3,10 @@ This module defines a pydantic schema for the payload of a jwt.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class TokenPayload(BaseModel):
@@ -15,15 +15,11 @@ class TokenPayload(BaseModel):
     """
 
     sub: str
-    permissions: List[str] = None
-    expire: datetime = Field(None, alias='exp')
+    permissions: List[str] = Field(list())
+    expire: datetime = Field(None, alias="exp")
 
     class Config:
         extra = "allow"
-
-    @validator('permissions', pre=True, always=True)
-    def validate_permissions(cls, v):
-        return v or list()
 
     def to_dict(self):
         """

--- a/armasec/token_payload.py
+++ b/armasec/token_payload.py
@@ -36,8 +36,9 @@ class TokenPayload(BaseModel):
         """
         Constructs a TokenPayload from a dictionary produced by `jwt.decode()`.
         """
-        return cls(
+        jwt_payload = dict(
             sub=payload_dict["sub"],
             permissions=payload_dict.get("permissions", list()),
-            expire=datetime.fromtimestamp(payload_dict["exp"], tz=timezone.utc),
+            expire=datetime.fromtimestamp(payload_dict.pop("exp"), tz=timezone.utc),
         )
+        return cls(**{**jwt_payload, **payload_dict})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "0.6.0"
+version = "0.6.1"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["OmniVector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/tests/test_token_payload.py
+++ b/tests/test_token_payload.py
@@ -31,8 +31,8 @@ def test_from_dict():
     embedded in a properly constructed and valid jwt.
     """
     exp = datetime(2021, 8, 13, 16, 38, 0, tzinfo=timezone.utc)
-    payload = TokenPayload.from_dict(
-        dict(
+    payload = TokenPayload(
+        **dict(
             sub="someone",
             permissions=["a", "b", "c"],
             exp=int(exp.timestamp()),


### PR DESCRIPTION
#### What
Pull request for changing the `from_dict` method of `TokenPayload` class

#### Why
Currently, the `from_dict` method builds the TokenPayload class with only three specific keys. This pull request code allows any kind of customization since the TokenPayload class would be built with all keys returned by `jwt.decode()`