### PR TITLE
Issue #9: Fixed faulty set logic for lockdown_all()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/>`_
 and this project adheres to `Semantic Versioning <http://semver.org/`_.
 
+Unreleased
+==========
+
+v0.7.3 - 2021-11-16
+===================
+- Fixed faulty set logic in lockdown_all()
+
 v0.7.2 - 2021-10-06
 ===================
 - Covers changes for v0.7.1 as well (debugging README render on pypi)

--- a/armasec/token_security.py
+++ b/armasec/token_security.py
@@ -126,7 +126,9 @@ class TokenSecurity(APIKeyBase):
                     """
                 )
                 self.debug_logger(message)
-                AuthorizationError.require_condition(token_permissions == my_permissions, message)
+                AuthorizationError.require_condition(
+                    my_permissions - token_permissions == set(), message
+                )
             elif self.permission_mode == PermissionMode.SOME:
                 message = unwrap(
                     f"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "0.7.2"
+version = "0.7.3"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/tests/test_token_security.py
+++ b/tests/test_token_security.py
@@ -101,7 +101,7 @@ async def test_injector_requires_all_scopes(client, build_secure_endpoint, build
     """
     exp = datetime(2021, 9, 17, 20, 56, 0, tzinfo=timezone.utc)
     token = build_rs256_token(
-        claim_overrides=dict(sub="me", permissions=["read:all"], exp=exp.timestamp()),
+        claim_overrides=dict(sub="me", permissions=["read:all", "read:other"], exp=exp.timestamp()),
     )
     headers = {"Authorization": f"bearer {token}"}
 
@@ -124,7 +124,7 @@ async def test_injector_requires_some_scopes(client, build_secure_endpoint, buil
     """
     exp = datetime(2021, 9, 28, 22, 22, 0, tzinfo=timezone.utc)
     token = build_rs256_token(
-        claim_overrides=dict(sub="me", permissions=["read:all"], exp=exp.timestamp()),
+        claim_overrides=dict(sub="me", permissions=["read:all", "read:other"], exp=exp.timestamp()),
     )
     headers = {"Authorization": f"bearer {token}"}
 


### PR DESCRIPTION
#### What
Fixed the set logic in the lockdown_all() method to use a difference instead of a perfect equivalance.

#### Why
The lockdown_all() method was failing if the token included some permissions beyond those required by the endpoint. D'oh!

Fixes Issue #9 
