### PR TITLE
Added selector for https protocol

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <http://semver.org/`_.
 Unreleased
 ==========
 
+v0.10.1 - 2022-05-04
+====================
+- Added ``use_https`` flag
+
 v0.10.0 - 2022-04-26
 ====================
 - Added support for python 3.6

--- a/armasec/openid_config_loader.py
+++ b/armasec/openid_config_loader.py
@@ -34,11 +34,14 @@ class OpenidConfigLoader:
         self.debug_logger = debug_logger if debug_logger else noop
 
     @staticmethod
-    def build_openid_config_url(domain):
+    def build_openid_config_url(domain: str, use_https: bool = True):
         """
         Builds a url for an openid configuration given a domain.
+
+        If ``use_https`` is not truthy, the url will be built with ``http`` instead.
         """
-        return f"https://{domain}/.well-known/openid-configuration"
+        protocol = "https" if use_https else "http"
+        return f"{protocol}://{domain}/.well-known/openid-configuration"
 
     def _load_openid_resource(self, url: str):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "0.10.0"
+version = "0.10.1"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"

--- a/tests/test_openid_config_loader.py
+++ b/tests/test_openid_config_loader.py
@@ -21,13 +21,23 @@ def test_config__is_lazy_loaded(rs256_domain, mock_openid_server):
     assert not mock_openid_server.openid_config_route.called
 
 
-def test_build_openid_config_url():
+def test_build_openid_config_url__default_protocol():
     """
-    Verify that the openid config url is built correctly.
+    Verify that the openid config url is built correctly using the default protocol.
     """
     assert (
         OpenidConfigLoader.build_openid_config_url("my.domain")
         == "https://my.domain/.well-known/openid-configuration"
+    )
+
+
+def test_build_openid_config_url__with_other_protocol():
+    """
+    Verify that the openid config url is built correctly using a non-default protocol.
+    """
+    assert (
+        OpenidConfigLoader.build_openid_config_url("my.domain", use_https=False)
+        == "http://my.domain/.well-known/openid-configuration"
     )
 
 


### PR DESCRIPTION
#### What
Added a flag to allow you to specify a non-https openid connect provider

#### Why
So that we can support local deployments of keycloak or other OIDC providers