### PR TITLE
ARMADA-526 Added  support to base Armasec class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <http://semver.org/`_.
 Unreleased
 ==========
 
+v0.10.2 - 2022-05-28
+====================
+- Exposed ``use_https`` in TokenSecurity and Armasec classes.
+
 v0.10.1 - 2022-05-04
 ====================
 - Added ``use_https`` flag

--- a/armasec/armasec.py
+++ b/armasec/armasec.py
@@ -20,6 +20,7 @@ class Armasec:
     def __init__(
         self,
         domain: str,
+        use_https: bool = True,
         audience: Optional[str] = None,
         algorithm: str = "RS256",
         debug_logger: Optional[Callable[[str], None]] = noop,
@@ -30,6 +31,8 @@ class Armasec:
 
         Args:
             domain:           The OIDC domain where resources are loaded
+            use_https:        If falsey, use ``http`` when pulling openid config from the OIDC
+                              server instead of ``https`` (the default).
             audience:         Optional designation of the token audience.
             algorithm:        The the algorithm to use for decoding. Defaults to RS256.
             debug_logger:     A callable, that if provided, will allow debug logging. Should be
@@ -38,6 +41,7 @@ class Armasec:
                               or debugging context.
         """
         self.domain = domain
+        self.use_https = use_https
         self.audience = audience
         self.algorithm = algorithm
         self.debug_logger = debug_logger
@@ -56,6 +60,7 @@ class Armasec:
         """
         return TokenSecurity(
             self.domain,
+            use_https=self.use_https,
             audience=self.audience,
             algorithm=self.algorithm,
             scopes=scopes,

--- a/armasec/openid_config_loader.py
+++ b/armasec/openid_config_loader.py
@@ -18,7 +18,12 @@ class OpenidConfigLoader:
     _config: Optional[OpenidConfig] = None
     _jwks: Optional[JWKs] = None
 
-    def __init__(self, domain: str, debug_logger: Optional[Callable[..., None]] = None):
+    def __init__(
+        self,
+        domain: str,
+        use_https: bool = True,
+        debug_logger: Optional[Callable[..., None]] = None,
+    ):
         """
         Initializes a base TokenManager.
 
@@ -27,10 +32,12 @@ class OpenidConfigLoader:
             secret:                  The secret key needed to decode a token
             domain:                  The domain of the OIDC provider. This is to construct the
                                      openid-configuration url
+            use_https:               If falsey, use ``http`` instead of ``https`` (the default).
             debug_logger:            A callable, that if provided, will allow debug logging. Should
                                      be passed as a logger method like `logger.debug`
         """
         self.domain = domain
+        self.use_https = use_https
         self.debug_logger = debug_logger if debug_logger else noop
 
     @staticmethod
@@ -67,7 +74,9 @@ class OpenidConfigLoader:
         """
         if not self._config:
             self.debug_logger("Fetching openid configration")
-            data = self._load_openid_resource(self.build_openid_config_url(self.domain))
+            data = self._load_openid_resource(
+                self.build_openid_config_url(self.domain, self.use_https)
+            )
             with AuthenticationError.handle_errors(
                 message="openid config data was invalid",
                 do_except=partial(log_error, self.debug_logger),

--- a/armasec/token_security.py
+++ b/armasec/token_security.py
@@ -34,6 +34,7 @@ class TokenSecurity(APIKeyBase):
     def __init__(
         self,
         domain: str,
+        use_https: bool = True,
         audience: Optional[str] = None,
         algorithm: str = "RS256",
         scopes: Optional[Iterable[str]] = None,
@@ -46,6 +47,8 @@ class TokenSecurity(APIKeyBase):
 
         Args:
             domain:           The OIDC domain where resources are loaded
+            use_https:        If falsey, use ``http`` when pulling openid config from the OIDC
+                              server instead of ``https`` (the default).
             audience:         Optional designation of the token audience.
             algorithm:        The the algorithm to use for decoding. Defaults to RS256.
             scopes:           Optional permissions scopes that should be checked
@@ -55,6 +58,7 @@ class TokenSecurity(APIKeyBase):
                               or debugging context.
         """
         self.domain = domain
+        self.use_https = use_https
         self.audience = audience
         self.algorithm = algorithm
         self.scopes = scopes
@@ -82,7 +86,9 @@ class TokenSecurity(APIKeyBase):
         """
         if self.manager is None:
             self.debug_logger("Lazy loading TokenManager")
-            loader = OpenidConfigLoader(self.domain, debug_logger=self.debug_logger)
+            loader = OpenidConfigLoader(
+                self.domain, use_https=self.use_https, debug_logger=self.debug_logger
+            )
             decoder = TokenDecoder(loader.jwks, self.algorithm, debug_logger=self.debug_logger)
             self.manager = TokenManager(
                 loader.config,

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,7 +111,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "auto-name-enum"
-version = "1.2.0"
+version = "2.0.0"
 description = "String-based Enum class that automatically assigns values"
 category = "main"
 optional = false
@@ -1235,7 +1235,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "218d142ef2c5419717194bcf376d87bdaafa894686bdaddce060d2f8215a5135"
+content-hash = "e3e4e5e1841b690a5ac31ee73e7ca1410bbc9958259c3521e49d3a4a19af8d5b"
 
 [metadata.files]
 aiocontextvars = [
@@ -1279,8 +1279,8 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 auto-name-enum = [
-    {file = "auto-name-enum-1.2.0.tar.gz", hash = "sha256:c07e94591b95fc3ede03aacba78433244a4a4f3a50a7d5b9c158d63274b8506c"},
-    {file = "auto_name_enum-1.2.0-py3-none-any.whl", hash = "sha256:d3b7e2f06a8e4d0256700205452a8bde1f5f3a97a108e4cbfc8eec688ab95f99"},
+    {file = "auto-name-enum-2.0.0.tar.gz", hash = "sha256:aa38d9c2730b95b0bb700cd93fb5f65a2a982f6d79bbbcd0c64e5bcfe8f3d5b1"},
+    {file = "auto_name_enum-2.0.0-py3-none-any.whl", hash = "sha256:fb9fe25985d7ef890e7b419d242b9ec145162ae1252121f8a5e3e8cca0e6d87a"},
 ]
 babel = [
     {file = "Babel-2.10.1-py3-none-any.whl", hash = "sha256:3f349e85ad3154559ac4930c3918247d319f21910d5ce4b25d439ed8693b98d2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "0.10.1"
+version = "0.10.2"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 license = "MIT"
@@ -19,7 +19,7 @@ py-buzz = "^3.1.0"
 # These must be included as a main dependency for the pytest extension to work out of the box
 respx = "^0.17.1"
 pytest = "^6.2.5"
-auto-name-enum = "^1.0.2"
+auto-name-enum = "^2"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.10"

--- a/tests/test_openid_config_loader.py
+++ b/tests/test_openid_config_loader.py
@@ -55,6 +55,20 @@ def test__load_openid_resource__success(mock_openid_server):
         assert loader._load_openid_resource("https://my.domain/blah") == dict(foo="bar")
 
 
+def test__load_openid_resource__with_http(mock_openid_server):
+    """
+    Verify that the helper method can fetch json data via a GET call to a url.
+    """
+    loader = OpenidConfigLoader("my.domain", use_https=False)
+    with respx.mock:
+        route = respx.get("http://my.domain/blah")
+        route.return_value = httpx.Response(
+            starlette.status.HTTP_200_OK,
+            json=dict(foo="bar"),
+        )
+        assert loader._load_openid_resource("http://my.domain/blah") == dict(foo="bar")
+
+
 def test__load_openid_resource__fails_on_failed_request(mock_openid_server):
     """
     Verify that the helper method throws an exception if the GET request fails.


### PR DESCRIPTION
#### What
Exposed the `use_https` flag in the Armasec and TokenSecurity classes.

#### Why
It was not so helpful for most of our use cases if it couldn't be hooked while instantiating Armasec.