### PR TITLE
Dusktreader/prepare for 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v1.2.0 - 2023-09-14
+
+- Added payload_claim_mapping to allow mapping claims to payload items
+
 ## v1.1.1 - 2023-08-14
 
 - Converted docs to use public branding images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## v1.2.0 - 2023-09-14
 
 - Added payload_claim_mapping to allow mapping claims to payload items
+- Added optional CLI for trying out logins and exploring tokens
 
 ## v1.1.1 - 2023-08-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "1.1.1"
+version = "1.2.0"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Engineering Team <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
Bumped minor version.

#### Why
To prepare for next release including CLI tools and payload claim mappings.