### PR TITLE
Made audience optional in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v2.0.3 - 2024-10-10
+
+- Made audience optional in cli
+
+## v2.0.2 - 2024-10-05
+
+- Added support for pytest 8
+
 ## v2.0.1 - 2024-05-29
 
 - Restored optional TokenPayload fields.

--- a/armasec_cli/auth.py
+++ b/armasec_cli/auth.py
@@ -144,7 +144,6 @@ def refresh_access_token(ctx: CliContext, token_set: TokenSet):
 
     If refresh fails, notify the user that they need to log in again.
     """
-    print("MAKE THIS FUCKING THING USE THE BASE URL")
     url = "/protocol/openid-connect/token"
     logger.debug(f"Requesting refreshed access token from {url}")
 
@@ -152,7 +151,7 @@ def refresh_access_token(ctx: CliContext, token_set: TokenSet):
         TokenSet,
         make_request(
             ctx.client,
-            "/protocol/openid-connect/token",
+            url,
             "POST",
             abort_message="The auth token could not be refreshed. Please try logging in again.",
             abort_subject="EXPIRED ACCESS TOKEN",

--- a/armasec_cli/config.py
+++ b/armasec_cli/config.py
@@ -1,6 +1,7 @@
 import json
 from functools import wraps
 from pathlib import Path
+from typing import Optional
 
 import snick
 import typer
@@ -21,7 +22,7 @@ class OidcProvider(AutoNameEnum):
 
 class Settings(BaseModel):
     oidc_domain: str
-    oidc_audience: str
+    oidc_audience: Optional[str] = None
     oidc_client_id: str
     oidc_use_https: bool = True
     oidc_max_poll_time: int = 5 * 60  # 5 minutes

--- a/armasec_cli/main.py
+++ b/armasec_cli/main.py
@@ -86,7 +86,7 @@ def logout():
 def set_config(
     domain: str = typer.Option(..., help="The domain used by your OIDC provider"),
     audience: str = typer.Option(
-        ...,
+        None,
         help="The audience required by your OIDC provider",
     ),
     client_id: str = typer.Option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "2.0.2"
+version = "2.0.3"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Engineering Team <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
#### What
This PR makes the "audience" setting optional in the armasec-cli.

#### Why
This is necessary so that you can use the CLI for clients that do not require an audience.
