### PR TITLE
Added a format_keycloak flag to build_rs256_token helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v2.1.1 - 2024-10-23
+
+- Added `format_keycloak` to `build_rs256_token()` helper
+
 ## v2.1.0 - 2024-10-13
 
 - Refactored pemission claim mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "2.1.0"
+version = "2.2.0"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Engineering Team <info@omnivector.solutions>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "armasec"
-version = "2.2.0"
+version = "2.1.1"
 description = "Injectable FastAPI auth via OIDC"
 authors = ["Omnivector Engineering Team <info@omnivector.solutions>"]
 license = "MIT"


### PR DESCRIPTION
In order to allow the `build_rs256_token()` helper to better support testing in apps that use keycloak for OIDC, I added a `format_keycloak` flag that automatically puts permissions provided in the `claim_overrides` into the correct place where they would be expected in a keycloak token.